### PR TITLE
Error while omite OutPutFormat parameter

### DIFF
--- a/PSFunctionExplorer/Code/Functions/Write-FUGraph.ps1
+++ b/PSFunctionExplorer/Code/Functions/Write-FUGraph.ps1
@@ -26,7 +26,7 @@ Function Write-FUGraph {
     .NOTES
         First Draft. For the moment the function only output graphviz datas. Soon you ll be able to generate a nice graph as a png, pdf ...
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = "Graph")]
     param (
         [Alias("FullName")]
         [Parameter(ValueFromPipeline=$True)]


### PR DESCRIPTION
When you use this without OutPutFormat parameter

Find-FUFunction -Path .\BuildOutput\PSItSupport\PSItSupport.psm1 | Write-FUGraph -ExportPath ".\Docs\MyGraph.png"

I have this error

Write-FUGraph : Parameter set cannot be resolved using the specified named parameters.
At line:1 char:68
+ ... ort\PSItSupport.psm1 | Write-FUGraph -ExportPath ".\Docs\MyGraph.png"
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (FUFunction:FUFunction) [Write-FUGraph], ParameterBindingException
    + FullyQualifiedErrorId : AmbiguousParameterSet,Write-FUGraph